### PR TITLE
Added tool for fetching URLs

### DIFF
--- a/fetch_urls.py
+++ b/fetch_urls.py
@@ -1,16 +1,18 @@
+"""Tool for fetching URLs from pushshift.io."""
+
 # Import dependencies
+import os
 from urllib import request as req
 import re
 import pycurl
-import os
 
 # Define values
 BASE_URL = "https://files.pushshift.io/reddit/submissions" # No trailing slash
-LINK_RE_PATTERN = "<a\s.*href=[\"'](\S+)[\"'][^>]*>\S*<\/a>"
+LINK_RE_PATTERN = r"<a\s.*href=[\"'](\S+)[\"'][^>]*>\S*<\/a>"
 OUTPUT_DIR = "pushshift_dumps_full"
 
 # Define functions
-def main(*args, **kwargs):
+def main():
     """The main entrypoint."""
 
     # Get links

--- a/fetch_urls.py
+++ b/fetch_urls.py
@@ -1,0 +1,37 @@
+# Import dependencies
+from urllib import request as req
+import re
+import pycurl
+import os
+
+# Define values
+BASE_URL = "https://files.pushshift.io/reddit/submissions" # No trailing slash
+LINK_RE_PATTERN = "<a\s.*href=[\"'](\S+)[\"'][^>]*>\S*<\/a>"
+OUTPUT_DIR = "pushshift_dumps_full"
+
+# Define functions
+def main(*args, **kwargs):
+    """The main entrypoint."""
+
+    # Get links
+    link_re = re.compile(LINK_RE_PATTERN)
+    raw_links = link_re.findall(req.urlopen(BASE_URL).read().decode("utf-8"))
+    filtered_links = [link for link in raw_links if link.startswith("./")]
+    individual_links = list(set(filtered_links))
+
+    # Download files
+    curl = pycurl.Curl()
+    os.makedirs(OUTPUT_DIR)
+    for link in individual_links:
+        filename = link[2:]
+        url = BASE_URL + "/" + filename
+        with open(os.path.join(OUTPUT_DIR, filename), "wb") as file:
+            curl.setopt(curl.URL, url)
+            curl.setopt(curl.WRITEDATA, file)
+            curl.perform()
+        print("Downloaded", filename)
+    curl.close()
+
+# Execute main function
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ tinysegmenter==0.3
 tldextract==2.2.0
 urllib3==1.24.1
 urlparse2==1.1.1
---install-option="--with-openssl" --install-option="--openssl-dir=/usr/local/opt/openssl" pycurl==7.21.5
+pycurl==7.21.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tinysegmenter==0.3
 tldextract==2.2.0
 urllib3==1.24.1
 urlparse2==1.1.1
+--install-option="--with-openssl" --install-option="--openssl-dir=/usr/local/opt/openssl" pycurl==7.21.5


### PR DESCRIPTION
This PR adds the tool fetch_urls.py which downloads the URLs from pushshift.io.
It uses pycurl, a wrapper for libcurl which requires SSL headers.