### PR TITLE
Efficient BPE tokenization 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ requests==2.21.0
 singledispatch==3.4.0.3
 six==1.12.0
 soupsieve==1.8
+spacy
 tinysegmenter==0.3
 tldextract==2.2.0
 urllib3==1.24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ numpy==1.16.1
 pandas==0.24.1
 pillow==5.4.1
 python-dateutil==2.8.0
+pytorch-pretrained-bert
 pytz==2018.9
 pyyaml==3.13
 recordtype==1.3

--- a/tokenize_text.py
+++ b/tokenize_text.py
@@ -3,33 +3,113 @@ import io
 import argparse
 import glob
 import os
+import tqdm
+import contextlib
+from pytorch_pretrained_bert import GPT2Tokenizer
+import numpy as np
+from multiprocessing import Pool
+from functools import partial
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--input_glob', type=str, default='*.txt')
-parser.add_argument('--output_dir', type=str, default='tokenized')
-args = parser.parse_args()
 
-nlp = spacy.load('en')
+def batch_iter(l, bs):
+    chunks = (len(l) - 1) // bs + 1
+    for i in range(chunks):
+        yield l[i*bs:(i+1)*bs]
 
-extraction_file_paths = glob.glob(args.input_glob)
 
-for extraction_file_path in extraction_file_paths:
+def tokenizeGpt2Spawn(args, nproc=None, **kwargs):
+    # Make sure output dir exists.
+    if not os.path.exists(args.output_dir):
+        os.mkdir(args.output_dir)
+    extraction_file_paths = glob.glob(args.input_glob)
 
-    path, filename = os.path.split(extraction_file_path)    
-    text_file = os.path.join(args.output_dir, filename.replace('.txt','.tokenized.txt'))
+    if nproc == 1:
+        print(tokenizeGpt2(extraction_file_paths, args, **kwargs))
+        return
+    with Pool() as pool:
+        omitted_files = 0
+        tqdm_bar = tqdm.tqdm(pool.imap_unordered(
+            partial(tokenizeGpt2, args=args, **kwargs),
+            batch_iter(extraction_file_paths, len(extraction_file_paths)//pool._processes)),
+            total=len(extraction_file_paths))
+        for o in tqdm_bar:
+            omitted_files += o
+            tqdm_bar.set_description(f'omit: {omitted_files}')
+        print(
+            f'Tokenized {tqdm_bar.total - omitted_files}/{tqdm_bar.total} files')
 
-    fi = io.open(extraction_file_path, 'r', encoding='utf-8')
-    fo = io.open(text_file, 'w', encoding='utf-8')
 
-    omitted_line_count = 0 
-    for line in fi:
-        if len(line) > 1:
-            doc = nlp(line)
-            fo.write(' '.join([x.text for x in doc]))                
-        else:
-            omitted_line_count += 1
-            
-    fi.close()
-    fo.close()
+def tokenizeGpt2(extraction_file_paths, args, min_length=20, combine=100000):
+    """Tokenize text using GPT-2's pretrained BPE encoder.
 
-    print('Omitting '+str(omitted_line_count)+ ' empty lines')
+    Saves as compressed npz files that can be loaded using `with np.load('filename.npz') as a: a['arr_0']`.
+    Omit files smaller than min_length tokens, which  are likely low quality.
+    """
+    tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+
+    EOT = tokenizer.encoder['<|endoftext|>']
+    omitted_files = 0
+    combined = []
+    for extraction_file_path in extraction_file_paths:
+        _, filename = os.path.split(extraction_file_path)
+        text_file = os.path.join(
+            args.output_dir, filename.replace('.txt', '.tokenized.npz'))
+        with io.open(extraction_file_path, 'r', encoding='utf-8') as fi:
+            # Suppress warnings about length.
+            with open(os.devnull, "w") as f, contextlib.redirect_stderr(f):
+                # Safe to concat by adding EOT.
+                out = tokenizer.encode(fi.read()) + [EOT]
+            if len(out) < min_length:
+                omitted_files += 1
+                continue
+            combined += out
+        if len(combined) > combine:
+            np.savez_compressed(text_file, combined)
+            combined = []
+    # Save the rest.
+    if combined:
+        np.savez_compressed(text_file, combined)
+
+    return omitted_files
+
+
+def tokenizeSpacy(args):
+    nlp = spacy.load('en')
+
+    extraction_file_paths = glob.glob(args.input_glob)
+
+    for extraction_file_path in extraction_file_paths:
+
+        path, filename = os.path.split(extraction_file_path)
+        text_file = os.path.join(
+            args.output_dir, filename.replace('.txt', '.tokenized.txt'))
+
+        fi = io.open(extraction_file_path, 'r', encoding='utf-8')
+        fo = io.open(text_file, 'w', encoding='utf-8')
+
+        omitted_line_count = 0
+        for line in fi:
+            if len(line) > 1:
+                doc = nlp(line)
+                fo.write(' '.join([x.text for x in doc]))
+            else:
+                omitted_line_count += 1
+
+        fi.close()
+        fo.close()
+
+        print('Omitting '+str(omitted_line_count) + ' empty lines')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input_glob', type=str, default='*.txt')
+    parser.add_argument('--output_dir', type=str, default='tokenized')
+    parser.add_argument('--tokenizer', type=str,
+                        default='spacy', choices=['spacy', 'gpt2'])
+    args = parser.parse_args()
+
+    if args.tokenizer == 'spacy':
+        tokenizeSpacy(args)
+    elif args.tokenizer == 'gpt2':
+        tokenizeGpt2Spawn(args)


### PR DESCRIPTION
* Use multiprocessing with all available cores
* Load files in batches of 10k files, combine at least 1e8 tokens per file. 
    * Compressed this is about 15MB/file
* Save results in compressed numpy arrays
* Append EOT token to each file so all numpy arrays can be safely concat'd
* Crappy tqdm progress. Doesn't handle multiproc very well but looks better than nothing.

My webtext is ~16M files. On a p3.2xlarge I estimate ~6 hours to encode the whole dataset into 1600 files.

Fixes #8 