### PR TITLE
Faster extraction

### DIFF
--- a/extract_text.py
+++ b/extract_text.py
@@ -47,7 +47,9 @@ def parse_archive(archive_fp, out_dir, n_procs, chunk_size=100):
     tmp_data_dir = pl.Path(archive_fp).with_suffix(".tmp")
 
     # extract tar first
-    if not tmp_data_dir.exists():
+    if tmp_data_dir.exists():
+        raise FileExistsError("Trying to extract archive to {}".format(tmp_data_dir))
+    else:
         tar = tarfile.open(archive_fp)
         tar.extractall(tmp_data_dir)
         tar.close()
@@ -75,6 +77,12 @@ def parse_archive(archive_fp, out_dir, n_procs, chunk_size=100):
             save_parsed_file(filename, text, out_dir)
     print("Could not parse {} files".format(unparsable))
 
+    # remove the extracted files
+    for filename in tmp_data_dir.iterdir():
+        if filename.is_file():
+            filename.unlink()
+    # and then the now (hopefully) empty directory
+    tmp_data_dir.rmdir()
 
 if __name__ == "__main__":
     month = extract_month(args.html_archive)

--- a/extract_text.py
+++ b/extract_text.py
@@ -66,23 +66,13 @@ def parse_archive(archive_fp, out_dir, n_procs, chunk_size=100):
     out_dir = pl.Path(out_dir)
     unparsable = 0
 
-    if n_procs == 1:
-        for filename in tqdm(file_gen(), total=num_remaining_files):
-            filename, text = parse_file(filename)
-
+    with mpl.Pool(n_procs) as pool:
+        for filename, text in tqdm(pool.imap(parse_file, file_gen(), chunksize=chunk_size), total=num_remaining_files):
             if not text:
                 unparsable += 1
                 continue
 
             save_parsed_file(filename, text, out_dir)
-    else:
-        with mpl.Pool(n_procs) as pool:
-            for filename, text in tqdm(pool.imap(parse_file, file_gen(), chunksize=chunk_size), total=num_remaining_files):
-                if not text:
-                    unparsable += 1
-                    continue
-
-                save_parsed_file(filename, text, out_dir)
     print("Could not parse {} files".format(unparsable))
 
 

--- a/extract_text.py
+++ b/extract_text.py
@@ -1,17 +1,18 @@
 from __future__ import print_function
 from __future__ import division
 
-from glob import glob
-import os.path as op
 import argparse, time, tarfile
+from glob import glob
 from hashlib import md5
 import multiprocessing as mpl
+import os.path as op
 import pathlib as pl
 
 import newspaper
 from tqdm import tqdm
 
 from utils import mkdir, chunks, extract_month
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--html_archive", type=str, default="scraped/RS_2017-04-4_data.xz")
@@ -44,25 +45,25 @@ def get_processed_files(out_dir):
 
 def parse_archive(archive_fp, out_dir, n_procs, chunk_size=100):
     tmp_data_dir = pl.Path(archive_fp).with_suffix(".tmp")
-    
+
     # extract tar first
     if not tmp_data_dir.exists():
         tar = tarfile.open(archive_fp)
         tar.extractall(tmp_data_dir)
         tar.close()
-    
 
+    # get files to process
     processed_files = set(get_processed_files(out_dir))
     num_total_files = len([_ for _ in tmp_data_dir.iterdir()])
     num_remaining_files = num_total_files - len(processed_files)
     print("{}/{} files already processed.".format(len(processed_files), num_total_files))
-    
+
     def file_gen():
         for filename in tmp_data_dir.iterdir():
             if filename.name not in processed_files and filename.is_file():
                 yield filename
-    
-    out_dir = pl.Path(out_dir) 
+
+    out_dir = pl.Path(out_dir)
     unparsable = 0
 
     if n_procs == 1:
@@ -83,7 +84,7 @@ def parse_archive(archive_fp, out_dir, n_procs, chunk_size=100):
 
                 save_parsed_file(filename, text, out_dir)
     print("Could not parse {} files".format(unparsable))
-    
+
 
 if __name__ == "__main__":
     month = extract_month(args.html_archive)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ six==1.12.0
 soupsieve==1.8
 tinysegmenter==0.3
 tldextract==2.2.0
+tqdm==4.32.2
 urllib3==1.24.1
 urlparse2==1.1.1
 pycurl==7.21.5


### PR DESCRIPTION
As mentioned in Issue #12 the extract text script is really slow. 

To speed things up I found out that the script is a lot faster if we first extract all files inside the archive and then let the `parse_file` function read the file itself. This requires additional space on the hard disk, but I just assume that everyone running this project has enough space. 

Just for my convenience I used the following libraries:
 1. Used [tqdm](https://github.com/tqdm/tqdm) to visualize progress (added to requirements). Can take this dependency out if its not helpful.
 2. Used pathlib (requires Python >= 3.4).